### PR TITLE
Add CVF links for the 5 accepted papers at GAZE 2023

### DIFF
--- a/_pages/home_2023.md
+++ b/_pages/home_2023.md
@@ -443,10 +443,10 @@ We will be hosting 2 invited speakers for the topic of gaze estimation. We will 
         <!-- <span class="award">Best Paper Award</span> -->
         <div class="btn-group btn-group-xs" role="group">
           <button class="btn btn-success">GAZE 2023</button>
-	  <!-- <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2022W/GAZE/papers/Qin_Learning-by-Novel-View-Synthesis_for_Full-Face_Appearance-Based_3D_Gaze_Estimation_CVPRW_2022_paper.pdf"><i class="fas fa-file-pdf"></i> PDF (CVF)</a>
-	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2022W/GAZE/supplemental/Qin_Learning-by-Novel-View-Synthesis_for_Full-Face_CVPRW_2022_supplemental.pdf"><i class="fas fa-file-pdf"></i> Suppl. (CVF)</a>
-	  <a class="btn btn-default" target="_blank" href="http://arxiv.org/abs/2201.07927"><i class="fas fa-archive"></i> arXiv</a>
-      <a class="btn btn-default" target="_blank" href="https://youtu.be/BUFTzo5DqXc"><i class="fas fa-video"></i> Video</a> -->
+	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2023W/GAZE/papers/Sood_Multimodal_Integration_of_Human-Like_Attention_in_Visual_Question_Answering_CVPRW_2023_paper.pdf"><i class="fas fa-file-pdf"></i> PDF (CVF)</a>
+	  <!--<a class="btn btn-default" target="_blank" href=""><i class="fas fa-file-pdf"></i> Suppl. (CVF)</a>-->
+	  <!--<a class="btn btn-default" target="_blank" href="http://arxiv.org/abs/2201.07927"><i class="fas fa-archive"></i> arXiv</a>-->
+          <!--<a class="btn btn-default" target="_blank" href="https://youtu.be/BUFTzo5DqXc"><i class="fas fa-video"></i> Video</a>-->
         </div>
     </div>
 
@@ -456,10 +456,10 @@ We will be hosting 2 invited speakers for the topic of gaze estimation. We will 
         <!-- <span class="award">Best Paper Award</span> -->
         <div class="btn-group btn-group-xs" role="group">
           <button class="btn btn-success">GAZE 2023</button>
-	  <!-- <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2022W/GAZE/papers/Qin_Learning-by-Novel-View-Synthesis_for_Full-Face_Appearance-Based_3D_Gaze_Estimation_CVPRW_2022_paper.pdf"><i class="fas fa-file-pdf"></i> PDF (CVF)</a>
-	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2022W/GAZE/supplemental/Qin_Learning-by-Novel-View-Synthesis_for_Full-Face_CVPRW_2022_supplemental.pdf"><i class="fas fa-file-pdf"></i> Suppl. (CVF)</a>
-	  <a class="btn btn-default" target="_blank" href="http://arxiv.org/abs/2201.07927"><i class="fas fa-archive"></i> arXiv</a>
-      <a class="btn btn-default" target="_blank" href="https://youtu.be/BUFTzo5DqXc"><i class="fas fa-video"></i> Video</a> -->
+	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2023W/GAZE/papers/Jin_Kappa_Angle_Regression_With_Ocular_Counter-Rolling_Awareness_for_Gaze_Estimation_CVPRW_2023_paper.pdf"><i class="fas fa-file-pdf"></i> PDF (CVF)</a>
+	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2023W/GAZE/supplemental/Jin_Kappa_Angle_Regression_CVPRW_2023_supplemental.pdf"><i class="fas fa-file-pdf"></i> Suppl. (CVF)</a>
+	  <!--<a class="btn btn-default" target="_blank" href="http://arxiv.org/abs/2201.07927"><i class="fas fa-archive"></i> arXiv</a>-->
+          <!--<a class="btn btn-default" target="_blank" href="https://youtu.be/BUFTzo5DqXc"><i class="fas fa-video"></i> Video</a>-->
         </div>
     </div>
 
@@ -469,10 +469,10 @@ We will be hosting 2 invited speakers for the topic of gaze estimation. We will 
         <!-- <span class="award">Best Paper Award</span> -->
         <div class="btn-group btn-group-xs" role="group">
           <button class="btn btn-success">GAZE 2023</button>
-	  <!-- <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2022W/GAZE/papers/Qin_Learning-by-Novel-View-Synthesis_for_Full-Face_Appearance-Based_3D_Gaze_Estimation_CVPRW_2022_paper.pdf"><i class="fas fa-file-pdf"></i> PDF (CVF)</a>
-	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2022W/GAZE/supplemental/Qin_Learning-by-Novel-View-Synthesis_for_Full-Face_CVPRW_2022_supplemental.pdf"><i class="fas fa-file-pdf"></i> Suppl. (CVF)</a>
-	  <a class="btn btn-default" target="_blank" href="http://arxiv.org/abs/2201.07927"><i class="fas fa-archive"></i> arXiv</a>
-      <a class="btn btn-default" target="_blank" href="https://youtu.be/BUFTzo5DqXc"><i class="fas fa-video"></i> Video</a> -->
+	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2023W/GAZE/papers/Wang_GazeCaps_Gaze_Estimation_With_Self-Attention-Routed_Capsules_CVPRW_2023_paper.pdf"><i class="fas fa-file-pdf"></i> PDF (CVF)</a>
+	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2023W/GAZE/supplemental/Wang_GazeCaps_Gaze_Estimation_CVPRW_2023_supplemental.pdf"><i class="fas fa-file-pdf"></i> Suppl. (CVF)</a>
+	  <!--<a class="btn btn-default" target="_blank" href="http://arxiv.org/abs/2201.07927"><i class="fas fa-archive"></i> arXiv</a>-->
+          <!--<a class="btn btn-default" target="_blank" href="https://youtu.be/BUFTzo5DqXc"><i class="fas fa-video"></i> Video</a>-->
         </div>
     </div>
 
@@ -482,10 +482,10 @@ We will be hosting 2 invited speakers for the topic of gaze estimation. We will 
         <!-- <span class="award">Best Paper Award</span> -->
         <div class="btn-group btn-group-xs" role="group">
           <button class="btn btn-success">GAZE 2023</button>
-	  <!-- <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2022W/GAZE/papers/Qin_Learning-by-Novel-View-Synthesis_for_Full-Face_Appearance-Based_3D_Gaze_Estimation_CVPRW_2022_paper.pdf"><i class="fas fa-file-pdf"></i> PDF (CVF)</a>
-	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2022W/GAZE/supplemental/Qin_Learning-by-Novel-View-Synthesis_for_Full-Face_CVPRW_2022_supplemental.pdf"><i class="fas fa-file-pdf"></i> Suppl. (CVF)</a>
-	  <a class="btn btn-default" target="_blank" href="http://arxiv.org/abs/2201.07927"><i class="fas fa-archive"></i> arXiv</a>
-      <a class="btn btn-default" target="_blank" href="https://youtu.be/BUFTzo5DqXc"><i class="fas fa-video"></i> Video</a> -->
+	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2023W/GAZE/papers/Horanyi_Where_Are_They_Looking_in_the_3D_Space_CVPRW_2023_paper.pdf"><i class="fas fa-file-pdf"></i> PDF (CVF)</a>
+	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2023W/GAZE/supplemental/Horanyi_Where_Are_They_CVPRW_2023_supplemental.pdf"><i class="fas fa-file-pdf"></i> Suppl. (CVF)</a>
+	  <!--<a class="btn btn-default" target="_blank" href="http://arxiv.org/abs/2201.07927"><i class="fas fa-archive"></i> arXiv</a>-->
+          <!--<a class="btn btn-default" target="_blank" href="https://youtu.be/BUFTzo5DqXc"><i class="fas fa-video"></i> Video</a>-->
         </div>
     </div>
 
@@ -495,10 +495,10 @@ We will be hosting 2 invited speakers for the topic of gaze estimation. We will 
         <!-- <span class="award">Best Paper Award</span> -->
         <div class="btn-group btn-group-xs" role="group">
           <button class="btn btn-success">GAZE 2023</button>
-	  <!-- <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2022W/GAZE/papers/Qin_Learning-by-Novel-View-Synthesis_for_Full-Face_Appearance-Based_3D_Gaze_Estimation_CVPRW_2022_paper.pdf"><i class="fas fa-file-pdf"></i> PDF (CVF)</a>
-	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2022W/GAZE/supplemental/Qin_Learning-by-Novel-View-Synthesis_for_Full-Face_CVPRW_2022_supplemental.pdf"><i class="fas fa-file-pdf"></i> Suppl. (CVF)</a>
-	  <a class="btn btn-default" target="_blank" href="http://arxiv.org/abs/2201.07927"><i class="fas fa-archive"></i> arXiv</a>
-      <a class="btn btn-default" target="_blank" href="https://youtu.be/BUFTzo5DqXc"><i class="fas fa-video"></i> Video</a> -->
+	  <a class="btn btn-default" target="_blank" href="https://openaccess.thecvf.com/content/CVPR2023W/GAZE/papers/Balim_EFE_End-to-End_Frame-To-Gaze_Estimation_CVPRW_2023_paper.pdf"><i class="fas fa-file-pdf"></i> PDF (CVF)</a>
+	  <!--<a class="btn btn-default" target="_blank" href=""><i class="fas fa-file-pdf"></i> Suppl. (CVF)</a>-->
+	  <a class="btn btn-default" target="_blank" href="https://arxiv.org/abs/2305.05526"><i class="fas fa-archive"></i> arXiv</a>
+          <!--<a class="btn btn-default" target="_blank" href="https://youtu.be/BUFTzo5DqXc"><i class="fas fa-video"></i> Video</a>-->
         </div>
     </div>
 


### PR DESCRIPTION
Adds the official URLs to PDF files on CVF OpenAccess for the accepted papers of GAZE 2023.